### PR TITLE
Add support for KPN as ISP

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Ensure that you're sitting adjacent to the stick on the network and that you hav
 # Frontier, with an assigned FRX523
 ./fs_xgspon_mod.py install GPON227000fe frontier FTRO12ab34cd --eqvid FRX523
 
+# KPN, keeping the serial as-is and basically just changing the ethernet uni slot to 1
+# this may also 'just work' for any other ISP that just requires slot 1 to be used instead of 10
+./fs_xgspon_mod.py install GPON227000fe kpn
+
 # Any arbitrary ISP as long as you know the equipment id/hwver/swver and necessary ethernet uni slot
 ./fs_xgspon_mod.py install GPON227000fe manual ALCL12ab34cd --hwver SOMETHING --swver ELSE --eqvid EQUIPMENT --eth_slot 10
 

--- a/fs_xgspon_mod.py
+++ b/fs_xgspon_mod.py
@@ -48,13 +48,25 @@ class ISP:
     EQID_TO_HWVER = {}
     EQID_TO_SWVER = {}
 
+    KEEP_SERIAL = False
+
     def __init__(self, args):
         found = True
 
         self.settings = []
 
-        self.serial = args.isp_ont_serial[4:].lower()
-        self.vendor = args.isp_ont_serial[:4]
+        if self.KEEP_SERIAL is True and args.isp_ont_serial is None:
+            # we prefer use the original serial, as there's no need to change it
+            self.serial = args.serial[4:].lower()
+            self.vendor = args.serial[:4]
+        else:
+            # but if we get an isp_ont_serial, we should use that
+            if args.isp_ont_serial is None:
+                # and also require it if this ISP will not cooperate
+                raise ValueError(f"the following arguments are required: isp_ont_serial")
+
+            self.serial = args.isp_ont_serial[4:].lower()
+            self.vendor = args.isp_ont_serial[:4]
 
         self.eth_slot = args.eth_slot or self.ETH10GESLOT
         self.eqvid = args.eqvid
@@ -195,6 +207,14 @@ class Frontier(ISP):
     EQID_TO_SWVER = {
         "FRX523": "R4.4.13.051", # Known working Dec 24 2023
     }
+
+class KPN(ISP):
+    # KPN always expects slot 1 to be used
+    ETH10GESLOT = 1
+
+    # KPN will register a new serial on the network if you ask them nicely
+    # so we prefer to keep the original serial as-is when configuring the module
+    KEEP_SERIAL = True
 
 class Manual(ISP):
     # basically just allows the raw arguments to be used as-is,
@@ -524,7 +544,7 @@ def install(args):
             self.RequestHandlerClass(request, client_address, self, config=settings.config)
 
     try:
-        with CigTelnet(args.onu_ip, args.fs_onu_serial) as tn:
+        with CigTelnet(args.onu_ip, args.serial) as tn:
             (addr, _) = tn.get_socket().getsockname()
 
             print("[+] Telnet connection established, login successful")
@@ -584,7 +604,7 @@ def install(args):
 
 def persist(args):
     try:
-        with CigTelnet(args.onu_ip, args.isp_ont_serial) as tn:
+        with CigTelnet(args.onu_ip, args.serial) as tn:
             print("[+] Telnet connection established, login successful")
 
             ls_rwdir_output = tn.sh_cmd("ls -l /mnt/rwdir/")
@@ -730,9 +750,9 @@ if __name__=="__main__":
     parse_telnet.set_defaults(func=telnet)
 
     parse_install = s.add_parser("install")
-    parse_install.add_argument("fs_onu_serial", type=parse_serial)
+    parse_install.add_argument("serial", type=parse_serial)
     parse_install.add_argument("isp", choices=ISP._name_to_class.keys())
-    parse_install.add_argument("isp_ont_serial", type=parse_serial)
+    parse_install.add_argument("isp_ont_serial", type=parse_serial, nargs='?', default=None)
     parse_install.add_argument("--onu_ip", default="192.168.100.1")
     parse_install.add_argument("--eqvid", type=parse_length(20))
     parse_install.add_argument("--hwver", type=parse_length(14))
@@ -743,7 +763,7 @@ if __name__=="__main__":
 
     parse_persist = s.add_parser("persist")
     parse_persist.add_argument("--onu_ip", default="192.168.100.1")
-    parse_persist.add_argument("isp_ont_serial", type=parse_serial)
+    parse_persist.add_argument("serial", type=parse_serial)
     parse_persist.set_defaults(func=persist)
 
     parse_rearm = s.add_parser("rearm")

--- a/fs_xgspon_mod.py
+++ b/fs_xgspon_mod.py
@@ -604,7 +604,7 @@ def install(args):
 
 def persist(args):
     try:
-        with CigTelnet(args.onu_ip, args.fs_onu_serial) as tn:
+        with CigTelnet(args.onu_ip, args.isp_ont_serial) as tn:
             print("[+] Telnet connection established, login successful")
 
             ls_rwdir_output = tn.sh_cmd("ls -l /mnt/rwdir/")
@@ -763,7 +763,7 @@ if __name__=="__main__":
 
     parse_persist = s.add_parser("persist")
     parse_persist.add_argument("--onu_ip", default="192.168.100.1")
-    parse_persist.add_argument("fs_onu_serial", type=parse_serial)
+    parse_persist.add_argument("isp_ont_serial", type=parse_serial)
     parse_persist.set_defaults(func=persist)
 
     parse_rearm = s.add_parser("rearm")

--- a/fs_xgspon_mod.py
+++ b/fs_xgspon_mod.py
@@ -57,8 +57,8 @@ class ISP:
 
         if self.KEEP_SERIAL is True and args.isp_ont_serial is None:
             # we prefer use the original serial, as there's no need to change it
-            self.serial = args.serial[4:].lower()
-            self.vendor = args.serial[:4]
+            self.serial = args.fs_onu_serial[4:].lower()
+            self.vendor = args.fs_onu_serial[:4]
         else:
             # but if we get an isp_ont_serial, we should use that
             if args.isp_ont_serial is None:
@@ -544,7 +544,7 @@ def install(args):
             self.RequestHandlerClass(request, client_address, self, config=settings.config)
 
     try:
-        with CigTelnet(args.onu_ip, args.serial) as tn:
+        with CigTelnet(args.onu_ip, args.fs_onu_serial) as tn:
             (addr, _) = tn.get_socket().getsockname()
 
             print("[+] Telnet connection established, login successful")
@@ -604,7 +604,7 @@ def install(args):
 
 def persist(args):
     try:
-        with CigTelnet(args.onu_ip, args.serial) as tn:
+        with CigTelnet(args.onu_ip, args.fs_onu_serial) as tn:
             print("[+] Telnet connection established, login successful")
 
             ls_rwdir_output = tn.sh_cmd("ls -l /mnt/rwdir/")
@@ -750,7 +750,7 @@ if __name__=="__main__":
     parse_telnet.set_defaults(func=telnet)
 
     parse_install = s.add_parser("install")
-    parse_install.add_argument("serial", type=parse_serial)
+    parse_install.add_argument("fs_onu_serial", type=parse_serial)
     parse_install.add_argument("isp", choices=ISP._name_to_class.keys())
     parse_install.add_argument("isp_ont_serial", type=parse_serial, nargs='?', default=None)
     parse_install.add_argument("--onu_ip", default="192.168.100.1")
@@ -763,7 +763,7 @@ if __name__=="__main__":
 
     parse_persist = s.add_parser("persist")
     parse_persist.add_argument("--onu_ip", default="192.168.100.1")
-    parse_persist.add_argument("serial", type=parse_serial)
+    parse_persist.add_argument("fs_onu_serial", type=parse_serial)
     parse_persist.set_defaults(func=persist)
 
     parse_rearm = s.add_parser("rearm")


### PR DESCRIPTION
First off; thanks for this great piece of work! It's amazing this tool exists and equally amazing how easy it is to use it.

This pull request aims to add support for KPN as ISP (which is a big Dutch internet provider with millions of customers). Basically the only change needed is to update the ONU's ethernet slot from 10 to 1. To make it as foolproof possible, I've made some modifications to the internals so people do not mistakenly rename their ONU's serial number, which is not required in KPN's case. This is because KPN has a self-service tool that allows you to register a custom ONU's serial number with them. As such, there's no need to override the serial number.

The reason I'm opening this pull request is that there are potentially a lot of interested power users that will come over to try it out by themselves, as it has been somewhat of a community/group effort to come to this result. We'd like to make the procedure as easy as possible for them. Of course, everyone understands these modifications are at their own risk.

I've successfully tested the changes in this pull request on my own connection and module, and they work properly. Of course, if you see anything you'd like to approach differently, let me know and I'll make modifications!

Just out of curiosity by the way; to your knowledge, how difficult/possible would it be to just change the ethernet port's slot number from 10 to 1 and leave the other modifications aside? Is there an alternative way to change it, or will it always require injecting a modified lib?