### PR TITLE
Add support for overriding just the slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,10 @@ Ensure that you're sitting adjacent to the stick on the network and that you hav
 # Frontier, with an assigned FRX523
 ./fs_xgspon_mod.py install GPON227000fe frontier FTRO12ab34cd --eqvid FRX523
 
-# KPN, keeping the serial as-is and basically just changing the ethernet uni slot to 1
-# this may also 'just work' for any other ISP that just requires slot 1 to be used instead of 10
+# KPN, just changing the ethernet uni slot from 10 to 1 and keeping the rest as-is
+# you can register the serial number of the module through the self-service tool of your provider
+./fs_xgspon_mod.py overrideslot GPON227000fe 1
+# you can also opt to fully install this mod, which also gives you e.g. SSH support (but strictly not neccesary)
 ./fs_xgspon_mod.py install GPON227000fe kpn
 
 # Any arbitrary ISP as long as you know the equipment id/hwver/swver and necessary ethernet uni slot
@@ -177,6 +179,25 @@ Creds for FS.com XGS-PON stick with serial GPON227000fe:
 
 The HMAC key used to derive passwords appears to be different between the various OEM customers, so I don't think this works for anything except the FS.com sticks.
 
+
+### Override ETH UNI slot
+
+If all you need is changing the ethernet UNI slot id, you can also use the `overrideslot` command which will place a config file on your module that overrides the slot number.
+
+This can be used as a more simple alternative to the full install method, and will not require any further modifications to any libraries nor re-arming.
+
+```
+./fs_xgspon_mod.py overrideslot GPON227000fe 1
+[+] Telnet connection established, login successful
+[!] /mnt/rwdir/sys.cfg already exists - continuing will remove any previous changes
+Continue? (y)es or (n)o: y
+[+] Ethernet port slot override applied -- press enter to reboot the ONU!
+reboot
+```
+
+You can remove the override by deleting the `/mnt/rwdir/sys.cfg` file through the telnet shell.
+
+If you are uncertain of the slot number to use, see the 'Finding right ETH10GESLOT' section below.
 
 ## Troubleshooting / Advanced
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,6 @@ Ensure that you're sitting adjacent to the stick on the network and that you hav
 
 # KPN, just changing the ethernet uni slot from 10 to 1 and keeping the rest as-is
 # you can register the serial number of the module through the self-service tool of your provider
-./fs_xgspon_mod.py overrideslot GPON227000fe 1
-# you can also opt to fully install this mod, which also gives you e.g. SSH support (but strictly not neccesary)
 ./fs_xgspon_mod.py install GPON227000fe kpn
 
 # Any arbitrary ISP as long as you know the equipment id/hwver/swver and necessary ethernet uni slot

--- a/fs_xgspon_mod.py
+++ b/fs_xgspon_mod.py
@@ -49,14 +49,14 @@ class ISP:
     EQID_TO_SWVER = {}
 
     KEEP_SERIAL = False
-    JUST_SLOT_OVERRIDE = False
+    PREFER_SLOT_OVERRIDE = False
 
     def __init__(self, args):
         found = True
 
         self.settings = []
 
-        if self.JUST_SLOT_OVERRIDE is True:
+        if self.PREFER_SLOT_OVERRIDE is True:
             print("[!] To make the ONU work on this ISP's network, just an ETH UNI slot override is needed")
             print("[!] Performing a slot override does not require any dangerous payloads to be applied")
             print("[!] However, you can also choose to go ahead and install the full modification")
@@ -232,7 +232,7 @@ class KPN(ISP):
 
     # KPN only requires a slot override to work
     # present the option to do just that to the user before we install anything modified
-    JUST_SLOT_OVERRIDE = True
+    PREFER_SLOT_OVERRIDE = True
 
 class Manual(ISP):
     # basically just allows the raw arguments to be used as-is,

--- a/fs_xgspon_mod.py
+++ b/fs_xgspon_mod.py
@@ -800,7 +800,7 @@ if __name__=="__main__":
     parse_install.add_argument("--eqvid", type=parse_length(20))
     parse_install.add_argument("--hwver", type=parse_length(14))
     parse_install.add_argument("--swver", type=parse_length(14))
-    parse_install.add_argument("--eth_slot", type=int, choices=(range(1, 65534)), metavar="[1-65534]")
+    parse_install.add_argument("--eth_slot", type=int, choices=(1, 10), metavar="[1,10]")
     parse_install.add_argument("--vlan_rules", type=parse_vlan_filter)
     parse_install.set_defaults(func=install)
 
@@ -817,7 +817,7 @@ if __name__=="__main__":
     parse_overrideslot = s.add_parser("overrideslot")
     parse_overrideslot.add_argument("--onu_ip", default="192.168.100.1")
     parse_overrideslot.add_argument("fs_onu_serial", type=parse_serial)
-    parse_overrideslot.add_argument("eth_slot", type=int, choices=(range(1, 65534)), metavar="[1-65534]")
+    parse_overrideslot.add_argument("eth_slot", type=int, choices=(1, 10), metavar="[1,10]")
     parse_overrideslot.set_defaults(func=overrideslot)
 
     args = p.parse_args()

--- a/fs_xgspon_mod.py
+++ b/fs_xgspon_mod.py
@@ -49,11 +49,26 @@ class ISP:
     EQID_TO_SWVER = {}
 
     KEEP_SERIAL = False
+    JUST_SLOT_OVERRIDE = False
 
     def __init__(self, args):
         found = True
 
         self.settings = []
+
+        if self.JUST_SLOT_OVERRIDE is True:
+            print("[!] To make the ONU work on this ISP's network, just an ETH UNI slot override is needed")
+            print("[!] Performing a slot override does not require any dangerous payloads to be applied")
+            print("[!] However, you can also choose to go ahead and install the full modification")
+            print("[!] When in doubt, you should probably try the less invasive (o)verride option first")
+
+            answer = input("Choose either (o)verride or (i)nstall: ")
+
+            if "o" in answer:
+                return overrideslot(args)
+            elif not "i" in answer:
+                print("[!] Invalid choice - exiting")
+                exit(1)
 
         if self.KEEP_SERIAL is True and args.isp_ont_serial is None:
             # we prefer use the original serial, as there's no need to change it
@@ -215,6 +230,10 @@ class KPN(ISP):
     # KPN will register a new serial on the network if you ask them nicely
     # so we prefer to keep the original serial as-is when configuring the module
     KEEP_SERIAL = True
+
+    # KPN only requires a slot override to work
+    # present the option to do just that to the user before we install anything modified
+    JUST_SLOT_OVERRIDE = True
 
 class Manual(ISP):
     # basically just allows the raw arguments to be used as-is,

--- a/fs_xgspon_mod.py
+++ b/fs_xgspon_mod.py
@@ -67,8 +67,7 @@ class ISP:
             if "o" in answer:
                 return overrideslot(args)
             elif not "i" in answer:
-                print("[!] Invalid choice - exiting")
-                exit(1)
+                raise ValueError(f"invalid choice: expected either o or i")
 
         if self.KEEP_SERIAL is True and args.isp_ont_serial is None:
             # we prefer use the original serial, as there's no need to change it


### PR DESCRIPTION
This pull allows for much easier and simpler 'fixing' of modules on networks that do not require any other modifications other than the slot number used.

I used 1-65534 for the eth_slot args as this seems to be the valid range for this param, but not entirely sure about that.

Let me know what you think!