### PR TITLE
Fix KPN install bug

### DIFF
--- a/fs_xgspon_mod.py
+++ b/fs_xgspon_mod.py
@@ -725,7 +725,7 @@ def overrideslot(args):
 
             tn.sh_cmd(f"echo ETH10GESLOT={args.eth_slot} > /mnt/rwdir/sys.cfg")
             print("[+] Ethernet port slot override applied")
-            tn.sh_cmd(f"cat /mnt/rwdir/sys.cfg")
+            print(tn.sh_cmd(f"cat /mnt/rwdir/sys.cfg"))
             print("[+] If above looks OK to you, press enter to reboot the ONU!")
             tn.write(b"reboot") # missing newline on purpose
             tn.interact()


### PR DESCRIPTION
This pull fixes #6 and also adds in some extra safeguards on the `overrideslot` command.
It also fixes the `install` command continuing execution anyways after redirecting to `overrideslot`.

My apologies for my previous pull request, where the issue was introduced. This time I fully tested the outcome and built in some extra functionality that will also echo back the contents of the override config file back to the user, so issues like #6 will be even less likely to happen in the future.