### PR TITLE
Add macOS support for CIG backdoor serial discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ FS.com doesn't distribute these with the serial you need to log in, requiring yo
 
 The serials take the form `GPONyymsssss` where `yy` is year (decimal, `23` for 2023), `m` is month (hex, `a` for October), and `sssss` is number within run. Production runs seem to be very small so brute force won't take much time if you can guess roughly when your stick was manufactured. I have yet to see any serial with `sssss` greater than `000fe`. These tools will try up through `00119` for each month.
 
-#### CIG Backdoor Brute Force (Linux only!)
+#### CIG Backdoor Brute Force (Linux & macOS only!)
 
 Brute forcing all possible serials should take around 20-30 seconds as of Jan 2024. It starts from the current month/year and works backwards, and assumes there were no units produced before Jan 2022.
 

--- a/fs_xgspon_mod.py
+++ b/fs_xgspon_mod.py
@@ -547,6 +547,67 @@ def discoverserial_cigbackdoor(args):
             if process_backdoor_block(args.onu_ip, s, pkt, next_serial_block):
                 break
 
+def discoverserial_cigbackdoor_mac(args):
+    try:
+        from scapy.all import (
+            Ether, sendp, srp1, ARP, conf,
+            get_if_hwaddr, Raw, raw
+        )
+    except ImportError:
+        print("[-] scapy not found, install via pip: pip install scapy")
+        sys.exit(1)
+
+    try:
+        with Telnet(args.onu_ip, 23, 2) as tn:
+            if b"Login as:" not in tn.read_until(b"Login as:", timeout=2):
+                print("[-] Unexpected Telnet prompt, wrong network?")
+                return
+        print("[+] Target reachable via Telnet. Querying ARP entry...")
+    except Exception as e:
+        print(f"[-] Telnet connection failed: {e}")
+        return
+
+    iface = conf.route.route(args.onu_ip)[0]
+    arp_resp = srp1(
+        Ether(dst="ff:ff:ff:ff:ff:ff")/ARP(pdst=args.onu_ip),
+        timeout=2,
+        iface=iface,
+        verbose=False
+    )
+    if not arp_resp:
+        print("[-] No ARP response, ensure L2 adjacency.")
+        return
+
+    victim_mac = arp_resp.hwsrc
+    src_mac = get_if_hwaddr(iface)
+    print(f"[+] Target {args.onu_ip} at MAC {victim_mac} via {iface} (src {src_mac})")
+
+    pkt = CIGBackdoorPacket()
+    pkt.dst_mac = tuple(int(o, 16) for o in victim_mac.split(':'))
+    pkt.src_mac = tuple(int(o, 16) for o in src_mac.split(':'))
+    pkt.ethertype = 0xc199
+    pkt.enable_hardcoded_creds = 1
+    pkt.operation = 0xeeee  # enable telnet server
+    pkt.command = 0xffffffff
+
+    raw_socket = conf.L2socket(iface=iface)
+    serials = serial_generator(*serial_search_params(args))
+
+    while True:
+        block = list(islice(serials, 1000))
+        if not block:
+            print("[-] Exhausted serials, try expanding range.")
+            break
+
+        payload = raw(pkt)
+        for serial in block:
+            frame = Ether(src=src_mac, dst=victim_mac, type=0xc199)/Raw(payload)
+            sendp(frame, iface=iface, verbose=False)
+
+        if process_backdoor_block(args.onu_ip, raw_socket, pkt, block):
+            print("[+] Serial found and backdoor activated!")
+            break
+
 def telnet(args):
     with CigTelnet(args.onu_ip, args.serial) as tn:
         tn.interact()
@@ -799,12 +860,14 @@ if __name__=="__main__":
     parse_discover.add_argument("--threads", default=2, type=int)
     parse_discover.set_defaults(func=discoverserial)
 
+    parse_discover_cig = s.add_parser("discoverserial_cig")
+    parse_discover_cig.add_argument("--onu_ip", default="192.168.100.1")
+    parse_discover_cig.add_argument("--year", default=None, type=lambda x: int(x) % 100)
+    parse_discover_cig.add_argument("--month", default=None, type=lambda x: int(x) & 0xf)
     if sys.platform == "linux":
-        parse_discover_cig = s.add_parser("discoverserial_cig")
-        parse_discover_cig.add_argument("--onu_ip", default="192.168.100.1")
-        parse_discover_cig.add_argument("--year", default=None, type=lambda x: int(x) % 100)
-        parse_discover_cig.add_argument("--month", default=None, type=lambda x: int(x) & 0xf)
         parse_discover_cig.set_defaults(func=discoverserial_cigbackdoor)
+    elif sys.platform == "darwin":
+        parse_discover_cig.set_defaults(func=discoverserial_cigbackdoor_mac)
 
     parse_telnet = s.add_parser("telnet")
     parse_telnet.add_argument("--onu_ip", default="192.168.100.1")


### PR DESCRIPTION
This pull request adds macOS support for the CIG Backdoor brute force functionality, previously limited to Linux, by introducing a new method and updating relevant documentation and code logic.

### macOS Support for CIG Backdoor Functionality:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L140-R140): Updated documentation to reflect that the CIG Backdoor brute force tool now supports both Linux and macOS platforms.
* [`fs_xgspon_mod.py`](diffhunk://#diff-e2ab65748b3590dbf8655ac82374d0430dccf00c511f38914ef5877fe1aab396R550-R610): Added the `discoverserial_cigbackdoor_mac` function to implement macOS-specific logic for discovering serials via the CIG Backdoor. This includes handling Telnet connections, querying ARP entries, and sending packets with hardcoded credentials to enable the backdoor.
* [`fs_xgspon_mod.py`](diffhunk://#diff-e2ab65748b3590dbf8655ac82374d0430dccf00c511f38914ef5877fe1aab396L802-R870): Updated the command-line argument parser to set the appropriate function (`discoverserial_cigbackdoor` for Linux or `discoverserial_cigbackdoor_mac` for macOS) based on the platform detected (`sys.platform`).